### PR TITLE
[#25] FEAT:플레이 함수로 베팅과 카드 기능 실행

### DIFF
--- a/contract/BlackJack.sol
+++ b/contract/BlackJack.sol
@@ -2,26 +2,25 @@
 
 pragma solidity >=0.7.0 <0.9.0;
 
-/**
- * @title Storage
- * @dev Store & retrieve value in a variable
- * @custom:dev-run-script ./scripts/deploy_with_ethers.ts
- */
-contract BlackJack {
+import "contracts/BlackJack_bet.sol";
+
+contract BlackJack is BlackJackBet {
     uint deckSize = 52;
     uint[] deck;
     uint[] dealerCards;
     uint[] playerCards;
     event completeShuffle(string result, string message);
+    event completeAll(string result, string message);
+    mapping(address => uint[]) public playerCardDeckMap;
+    mapping(address => uint[]) public dealerCardDeckMap;
 
-    function createDeck() public returns(uint[] memory){
+    function createDeck() public {
         for (uint i = 0; i < deckSize; i++){
             deck.push(i);
         }
-      return deck;
     }
 
-    function shuffleDeck() external {
+    function shuffleDeck() public {
         for (uint i = 0; i < deck.length; i++) {
             uint n = i + uint(keccak256(abi.encodePacked(block.timestamp))) % (deck.length - i);
             uint temp = deck[n];
@@ -34,14 +33,16 @@ contract BlackJack {
             deck.pop();
             playerCards.push(card);
         }
+        playerCardDeckMap[msg.sender] = playerCards;
 
         for (uint i = 6; i < 12; i++) {
             uint card = deck[deck.length - 1];
             deck.pop();
             dealerCards.push(card);
         }
+        dealerCardDeckMap[msg.sender] = dealerCards;
 
-        emit completeShuffle("success", "Card Deck is Ready!");
+        emit completeShuffle("success", "Card is Ready!");
     }   
 
     function getDealerCards() public view returns (uint[] memory){
@@ -55,4 +56,15 @@ contract BlackJack {
     function getDeck() public view returns (uint[] memory){
         return deck;
     }
+
+    function playBlackJack() public payable {
+        uint betAmount = msg.value;
+        address userAddress = msg.sender;
+        userBet(betAmount);
+        playerBetAmount[userAddress] = betAmount;
+        createDeck();
+        shuffleDeck();
+        emit completeAll("success", "Play is Ready!");
+    }
+
 }

--- a/contract/BlackJack_bet.sol
+++ b/contract/BlackJack_bet.sol
@@ -7,13 +7,14 @@ pragma solidity >=0.7.0 <0.9.0;
  * @dev Store & retrieve value in a variable
  * @custom:dev-run-script ./scripts/deploy_with_ethers.ts
  */
-contract BlackJack {
+contract BlackJackBet {
     address _contract = address(this);
     address _player = msg.sender;
     uint256 _pBet;
     string _dMsg;
     address payable p_player = payable(_player);
     address payable p_contract = payable(_contract);
+    mapping(address => uint) public playerBetAmount;
 
     event completeUserBet(string result, string message, uint256 bet);
     event howMuch(uint256 _value);
@@ -56,7 +57,7 @@ contract BlackJack {
     }
 
     function callToContract() public payable {
-        require(msg.sender.balance >= msg.value, "Your Balance is not enought");
+        require(msg.sender.balance >= msg.value, "Your Balance is not enough");
         (bool sent, ) = address(this).call{value: msg.value, gas: 1000}("");
         require(sent, "fail send ether.");
         emit completeUserBet("success", _dMsg, msg.value);


### PR DESCRIPTION
## ☑️ 내용
### 요약
<!--한 줄 요약을 적어주세요-->
-플레이 함수로 베팅과 카드 기능 실행

### 변경 내용
<!--변경된 내용을 상세히 적어주세요. 상기 한 줄 요약으로 끝낼 수 있다면 작성하지 않으셔도 됩니다.-->
해당 함수 호출하면 
베팅한 금액 받아 컨트랙트 밸런스로 저장
베팅 금액 유저주소에 맵핑,
덱 셔플해서 유저주소에 똑같이 맵핑,
완료됐다고 이벤트 발생.
<br/>

|Linked Issue No.|
|-:|
|<!--연관 이슈번호를 삽입해주세요-->#|